### PR TITLE
Add reference to .net4 & update wsus content dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Massive credit to the below resources that really did 90% of this for me. This t
 * https://github.com/AlsidOfficial/WSUSpendu - powershell tool for abusing WSUS
 * https://github.com/ThunderGunExpress/Thunder_Woosus - Csharp tool for abusing WSUS
 
+## Building
+This project requires .NET Framework v4.0. You can download that here: https://dotnet.microsoft.com/en-us/download/dotnet-framework/net40. It may work with newer versions of .NET, however, it's not been tested.
+
 ## Help Menu
 
 ```


### PR DESCRIPTION
This pull request is to:

1. Add a reference and link to .NET 4.0 in `README.md`
2. Pull the WSUS Content Directory location from the SQL database instead of the registry. In my testing, the registry path was one folder higher than where the patches get downloaded to. This results in the payload failing to download until it's in the correct folder.